### PR TITLE
fix: resolve warning in Elixir 1.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,4 +118,5 @@ jobs:
             otp: 26
           - elixir: 1.17
             otp: 27
-
+          - elixir: 1.18
+            otp: 27

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16
-erlang 26.0
+elixir 1.18
+erlang 27.2

--- a/lib/ua_parser/processor.ex
+++ b/lib/ua_parser/processor.ex
@@ -25,7 +25,7 @@ defmodule UAParser.Processor do
     # result: {user_agents, os, devices}
     groups
     |> Enum.map(&compile_groups/1)
-    |> to_tuple
+    |> :erlang.list_to_tuple()
   end
 
   defp compile_group(group) do
@@ -57,13 +57,5 @@ defmodule UAParser.Processor do
   defp to_keyword([{key, value} | tails]) do
     keyword = {atom_key(key), String.Chars.to_string(value)}
     [keyword | to_keyword(tails)]
-  end
-
-  defp to_tuple(values, tuple \\ {})
-  defp to_tuple([], tuple), do: tuple
-
-  defp to_tuple([head | tail], tuple) do
-    tuple = Tuple.append(tuple, head)
-    to_tuple(tail, tuple)
   end
 end


### PR DESCRIPTION
Hello 👋🏼 

This PR resolves the [only] warning emitted by this library in Elixir 1.18. Function `Tuple.append/2` is deprecated in favor of `Tuple.insert_at/3`. However, I believe the needs of this library can be better served by a related function from the `:erlang` module.

This PR also adds 1.18 to the matrix for CI.

Cheers! ❤️ 